### PR TITLE
5518: set sequence

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,5 @@
 databaseChangeLog:
   - include:
       file: db/changelog/v2023/create_events.sql
+  - include:
+      file: db/changelog/v2023/set_sequence_value.sql

--- a/src/main/resources/db/changelog/v2023/set_sequence_value.sql
+++ b/src/main/resources/db/changelog/v2023/set_sequence_value.sql
@@ -1,0 +1,20 @@
+select setval('event.event_api_request_id_seq', (SELECT MAX(id) FROM event.event_api_request));
+ALTER TABLE event.event_api_request ALTER COLUMN id SET DEFAULT nextval('event.event_api_request_id_seq');
+
+select setval('event.event_api_response_id_seq', (SELECT MAX(id) FROM event.event_api_response));
+ALTER TABLE event.event_api_response ALTER COLUMN id SET DEFAULT nextval('event.event_api_response_id_seq');
+
+select setval('event.event_bene_reload_id_seq', (SELECT MAX(id) FROM event.event_bene_reload));
+ALTER TABLE event.event_bene_reload ALTER COLUMN id SET DEFAULT nextval('event.event_bene_reload_id_seq');
+
+select setval('event.event_bene_search_id_seq', (SELECT MAX(id) FROM event.event_bene_search));
+ALTER TABLE event.event_bene_search ALTER COLUMN id SET DEFAULT nextval('event.event_bene_search_id_seq');
+
+select setval('event.event_error_id_seq', (SELECT MAX(id) FROM event.event_error));
+ALTER TABLE event.event_error ALTER COLUMN id SET DEFAULT nextval('event.event_error_id_seq');
+
+select setval('event.event_file_id_seq', (SELECT MAX(id) FROM event.event_file));
+ALTER TABLE event.event_file ALTER COLUMN id SET DEFAULT nextval('event.event_file_id_seq');
+
+select setval('event.event_job_status_change_id_seq', (SELECT MAX(id) FROM event.event_job_status_change));
+ALTER TABLE event.event_job_status_change ALTER COLUMN id SET DEFAULT nextval('event.event_job_status_change_id_seq');


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-5518](https://jira.cms.gov/browse/AB2D-5518) - Description

Dan reported that Metrics dashboard is not refreshing bene counts, upon further investigation found out that  "event.event_bene_search" table data is missing.

***Related Tickets***

[AB2D-5518](https://jira.cms.gov/browse/AB2D-5518) - Reason it's related

### What Does This PR Do?

This PR will set the sequence value start from the current max ID + 1.

### What Should Reviewers Watch For?

Whether the sequence is exist in each table in event schema and when the new data insert, it should start from the current max ID + 1.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

Set the sequence value start from the current max ID + 1.

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure