### PR TITLE
PLT-142 Add region and use aws-params-env-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set env vars from AWS params
         uses: gsf/aws-params-env-action@v1
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
             ARTIFACTORY_URL=/artifactory/url

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           gradle-version: 7.4.2
 
       - name: Set env vars from AWS params
-        uses: gsf/aws-params-env-action@v1
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@plt-142-aws-param-action
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  Test:
+  test:
     runs-on: self-hosted
 
     steps:
@@ -24,27 +24,15 @@ jobs:
         with:
           gradle-version: 7.4.2
 
-      - name: Set env vars
-        run: |
-          shopt -s expand_aliases # https://github.com/actions/toolkit/issues/766#issuecomment-928305811
-          alias param="aws ssm get-parameter --output text --query Parameter.Value --with-decryption --name"
-
-          artifactory_url="$(param /artifactory/url)"
-          echo "ARTIFACTORY_URL=$artifactory_url" >> "$GITHUB_ENV"
-
-          artifactory_user="$(param /artifactory/user)"
-          echo "ARTIFACTORY_USER=$artifactory_user" >> "$GITHUB_ENV"
-
-          artifactory_password="$(param /artifactory/password)"
-          echo "::add-mask::$artifactory_password"
-          echo "ARTIFACTORY_PASSWORD=$artifactory_password" >> "$GITHUB_ENV"
-
-          sonarqube_url="$(param /sonarqube/url)"
-          echo "SONAR_HOST_URL=$sonarqube_url" >> "$GITHUB_ENV"
-
-          sonarqube_token="$(param /sonarqube/token)"
-          echo "::add-mask::$sonarqube_token"
-          echo "SONAR_TOKEN=$sonarqube_token" >> "$GITHUB_ENV"
+      - name: Set env vars from AWS params
+        uses: gsf/aws-params-env-action@v1
+        with:
+          params: |
+            ARTIFACTORY_URL=/artifactory/url
+            ARTIFACTORY_USER=/artifactory/user
+            ARTIFACTORY_PASSWORD=/artifactory/password
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
 
       - name: Run tests
         run: gradle test ${RUNNER_DEBUG:+"--debug"}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           gradle-version: 7.4.2
 
       - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@plt-142-aws-param-action
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-142

## 🛠 Changes

Added AWS_REGION environment variable and the aws-param-env-action.

## ℹ️ Context for reviewers

The AWS_REGION environment variable is required on the new runner infrastructure. This also seemed like a good chance to test out the aws-params-env-action added to the platform repo.

## ✅ Acceptance Validation

I'm updating terraform for the new runner infra at https://github.com/CMSgov/ab2d-bcda-dpc-platform/pull/6 until we get a passing test workflow.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
