### PR TITLE
PLT-575 Update Github Actions Runners to support node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   test:
     runs-on: self-hosted
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## 🎫 Ticket

[PLT-338](https://jira.cms.gov/browse/PLT-575)

## 🛠 Changes

- ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION was set to true in the workflow

## ℹ️ Context

The github actions jobs are failing due to unsecured nodejs16 version

## 🧪 Validation

GH actions test passes
