### PR TITLE
PLT-575 update all events workflows for nodejs20 workaround

### DIFF
--- a/.github/workflows/build-release-dev.yml
+++ b/.github/workflows/build-release-dev.yml
@@ -6,7 +6,8 @@ on: workflow_dispatch
 jobs:
   release:
     runs-on: self-hosted
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-release-impl.yml
+++ b/.github/workflows/build-release-impl.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   release:
     runs-on: self-hosted
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-release-prod.yml
+++ b/.github/workflows/build-release-prod.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   release:
     runs-on: self-hosted
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-release-sbx.yml
+++ b/.github/workflows/build-release-sbx.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   release:
     runs-on: self-hosted
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## 🎫 Ticket

[PLT-338](https://jira.cms.gov/browse/PLT-575)

## 🛠 Changes

- ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION was set to true in the workflow

## ℹ️ Context

The github actions jobs are failing due to unsecured nodejs16 version

## 🧪 Validation

GH actions test passes
