### PR TITLE
Update container image to amazoncorretto:21-al2023-jdk

### DIFF
--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -50,9 +50,7 @@ jobs:
           SHA_SHORT=$(git rev-parse --short HEAD)
           aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN
           ECR_URI="$ECR_DOMAIN/$ECR_REPO"
-          
-          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME"
-          
+          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME-$SHA_SHORT"
           docker build -t "$ECR_URI:$TAG_SHORT" .
           docker push "$ECR_URI" --all-tags
           echo "Published **$ECR_URI:$TAG_SHORT**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}
     env:
       ECR_REPO: ab2d-events
-      TAG_PREFIX: event-service # TODO should this use `events-` or `event-` ? Terraform uses `event-` IIRC
+      TAG_PREFIX: event-service
       AWS_ACCOUNT: ${{ secrets.GF_NON_PROD_ACCOUNT }}
     permissions:
       contents: read

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -1,5 +1,5 @@
 name: Deploy events GF
-run-name: deploy-gf ${{ inputs.environment }} ${{ inputs.image_tag_suffix }}
+run-name: deploy-gf ${{ inputs.environment }} ${{ inputs.image_tag }}
 
 on:
   workflow_call:
@@ -7,7 +7,7 @@ on:
       environment:
         required: true
         type: string
-      tag_suffix:
+      image_tag:
         required: true
         type: string
   workflow_dispatch:
@@ -21,9 +21,9 @@ on:
           - test
           - sandbox
           - prod
-      image_tag_suffix:
-        description: Image tag suffix
-        required: false
+      image_tag:
+        description: ECR image tag (event-service-<branch>-<SHA>)
+        required: true
         type: string
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
     uses: cmsgov/ab2d/.github/workflows/terraform-microservices-gf.yml@main
     with:
       environment: ${{ inputs.environment }}
-      events_service_image: event-service-${{ inputs.image_tag_suffix || github.ref }}
+      events_service_image: ${{ inputs.image_tag }}
       apply: true
       ref: main
       runner: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -1,5 +1,5 @@
-name: promote-gf
-run-name: promote-gf ${{ inputs.image_tax_prefix }}
+name: deploy-gf
+run-name: deploy-gf ${{ inputs.image_tax_prefix }}
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -1,69 +1,42 @@
-name: deploy-gf
-run-name: deploy-gf ${{ inputs.image_tax_prefix }}
+name: Deploy events GF
+run-name: deploy-gf ${{ inputs.environment }} ${{ inputs.image_tag_suffix }}
 
 on:
   workflow_call:
     inputs:
+      environment:
+        required: true
+        type: string
       tag_suffix:
         required: true
         type: string
   workflow_dispatch:
     inputs:
+      environment:
+        description: AB2D environment
+        required: true
+        type: choice
+        options:
+          - dev
+          - test
+          - sandbox
+          - prod
       image_tag_suffix:
-        description: Docker tag suffix
+        description: Image tag suffix
         required: false
         type: string
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
-  promote:
+  apply_tofu:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}
-    env:
-      TAG_NAME: event-service-${{ inputs.image_tag_suffix || github.ref }}
-      SOURCE_REPO: ab2d-events
-    steps:
-      - name: Define destination repo
-        id: repos
-        run: |
-          echo "DEST_REPO=ab2d-events" >> $GITHUB_OUTPUT 
-
-      - name: Authenticate to source account (pull from test)
-        uses: aws-actions/configure-aws-credentials@v4.0.2
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.GF_NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/ab2d-dev-github-actions
-
-      - name: Pull image from test ECR
-        id: pull-image
-        run: |
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          SRC_ECR="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
-          docker login --username AWS --password-stdin $SRC_ECR <<< $(aws ecr get-login-password)
-          echo "Pulling $SRC_ECR/$SOURCE_REPO:$TAG_NAME"
-          docker pull "$SRC_ECR/$SOURCE_REPO:$TAG_NAME"
-          echo "IMAGE=$SRC_ECR/$SOURCE_REPO:$TAG_NAME" >> $GITHUB_OUTPUT
-
-      - name: Authenticate to destination account (push)
-        uses: aws-actions/configure-aws-credentials@v4.0.2
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: |
-            arn:aws:iam::${{ secrets.GF_PROD_ACCOUNT }}:role/delegatedadmin/developer/ab2d-sandbox-github-actions
-
-      - name: Tag and push image to destination ECR
-        env:
-          DEST_REPO: ${{ steps.repos.outputs.DEST_REPO }}
-          IMAGE: ${{ steps.pull-image.outputs.IMAGE }}
-        run: |
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          DEST_ECR="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
-          docker login --username AWS --password-stdin $DEST_ECR <<< $(aws ecr get-login-password)
-          echo "Tagging and pushing image to $DEST_ECR/$DEST_REPO:$TAG_NAME"
-          docker tag "$IMAGE" "$DEST_ECR/$DEST_REPO:$TAG_NAME"
-          docker push "$DEST_ECR/$DEST_REPO:$TAG_NAME"
+    uses: cmsgov/ab2d/.github/workflows/terraform-microservices-gf.yml@main
+    with:
+      environment: ${{ inputs.environment }}
+      contracts_service_image: event-service-${{ inputs.image_tag_suffix || github.ref }}
+      apply: true
+      ref: main
+      runner: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}
+    secrets:
+      aws_account: ${{contains(fromJSON('["dev", "test"]'), inputs.environment) && secrets.GF_NON_PROD_ACCOUNT || secrets.GF_PROD_ACCOUNT}}

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -34,7 +34,7 @@ jobs:
     uses: cmsgov/ab2d/.github/workflows/terraform-microservices-gf.yml@main
     with:
       environment: ${{ inputs.environment }}
-      contracts_service_image: event-service-${{ inputs.image_tag_suffix || github.ref }}
+      events_service_image_tag: event-service-${{ inputs.image_tag_suffix || github.ref }}
       apply: true
       ref: main
       runner: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -34,7 +34,7 @@ jobs:
     uses: cmsgov/ab2d/.github/workflows/terraform-microservices-gf.yml@main
     with:
       environment: ${{ inputs.environment }}
-      events_service_image_tag: event-service-${{ inputs.image_tag_suffix || github.ref }}
+      events_service_image: event-service-${{ inputs.image_tag_suffix || github.ref }}
       apply: true
       ref: main
       runner: codebuild-ab2d-events-${{github.run_id}}-${{github.run_attempt}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2-jdk
+FROM amazoncorretto:21-al2023-jdk
 WORKDIR /usr/src/ab2d-events
 ADD build/libs/*.jar /usr/src/ab2d-events/ab2d-event.jar
 


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-6812
- https://jira.cms.gov/browse/AB2D-6766

## 🛠 Changes

- Update `Dockerfile` to use **amazoncorretto:21-al2023-jdk** container image
- Use same `deploy-gf` workflow as contracts and properties
- Minor workflow cleanup

## ℹ️ Context

From Brian Hodges:
```
Please move to a supported tagged release that is not AL2-based. 17-al2023-jdk should be a straightforward. This needs to occur for all containerized AB2D services.
```

Folks have reported better memory usage using correta 21.  

## 🧪 Validation

Validated in `dev`.

https://github.com/CMSgov/ab2d-events/actions/runs/16498827601